### PR TITLE
set up mongodb interactions from fetch service

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
         "object-shorthand": "off",
         "no-underscore-dangle": ["error", { "allowAfterThis": true }],
         "comma-dangle": ["error", "never"],
-        "no-console": 0
+        "no-console": 0,
+        "no-plusplus": "off"
     },
     "env": {
         "jest": true

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ node_modules/
 # MACOS sillyness
 .DS_Store
 
-# WebStorm project files
+# WebStorm and vscode project files
 src/APIServer/.idea/
 .idea/
+.vscode
+

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "cookie-parser": "~1.4.3",
     "db-migrate": "^0.11.1",
     "debug": "~2.6.9",
+    "deep-equal": "^1.0.1",
     "docco": "^0.8.0",
     "express": "~4.16.0",
     "express-json-views": "^0.1.1",
+    "fast-deep-equal": "^2.0.1",
     "global": "^4.3.2",
     "http-errors": "~1.6.2",
     "jsdoc": "^3.5.5",
@@ -32,9 +34,7 @@
     "mongodb": "^3.1.0-beta4",
     "mongoose": "^5.1.3",
     "morgan": "~1.9.0",
-    "pug": "2.0.0-beta11",
-    "fast-deep-equal": "^2.0.1",
-    "global": "^4.3.2"
+    "pug": "2.0.0-beta11"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "jest": {
+     "testEnvironment": "node",
+     "testURL": "http://localhost/"
+  },
   "scripts": {
     "test": "jest --verbose",
     "check": "npm run lint && npm run test",

--- a/src/APIServer/app.js
+++ b/src/APIServer/app.js
@@ -16,7 +16,7 @@ const noticesRouter = require('./routes/notices');
 
 // DB connection
 const db = require('./model/db'); // eslint-disable-line no-unused-vars
-const notice = require('./model/notice'); // eslint-disable-line no-unused-vars
+const notice = require('../Database/schema/notice'); // eslint-disable-line no-unused-vars
 
 // Connecting routers
 app.use('/notice', noticesRouter);

--- a/src/APIServer/tests/app.test.js
+++ b/src/APIServer/tests/app.test.js
@@ -4,7 +4,7 @@ const mongoose = require('mongoose');
 
 mongoose.Promise = Promise;
 const app = require('../app');
-const Notice = require('../model/notice');
+const Notice = require('../../Database/schema/notice');
 
 describe('Test Mongoose database connection', () => {
   test('Test connection', (done) => {

--- a/src/Database/actions.js
+++ b/src/Database/actions.js
@@ -1,0 +1,77 @@
+const mongoose = require('mongoose');
+const Notice = require('./schema/notice.js');
+
+const mongoURI = 'mongodb://mongo/TWbackend?replicaSet=rs';
+
+async function insertNotices(notices) {
+  mongoose.connect(mongoURI).then(() => {
+    Notice.collection.insert(notices, (err) => {
+      if (err) {
+        console.log(err);
+        process.exit();
+      }
+    });
+  }).catch((err) => {
+    console.log(err);
+    console.log('Could not connect to the database. Exiting now...');
+    process.exit();
+  });
+}
+
+async function getCurrentNotices(callback) {
+  mongoose.connect(mongoURI).then(() => {
+    Notice.find({}).lean().exec((err, result) => {
+      if (err) {
+        throw err;
+      }
+      callback(result);
+    });
+  });
+}
+
+async function deleteNotices(notices) {
+  mongoose.connect(mongoURI).then(() => {
+    Notice.remove({ referencenum: { $in: notices } }, (err) => {
+      console.log(err);
+      process.exit();
+    });
+  }).catch((err) => {
+    console.log(err);
+    process.exit();
+  });
+}
+
+async function deleteAllNotices() {
+  mongoose.connect(mongoURI).then(() => {
+    Notice.remove({}, (err) => {
+      console.log(err);
+      process.exit();
+    });
+  }).catch((err) => {
+    console.log(err);
+    process.exit();
+  });
+}
+
+async function updateNotice(referenceNum, newVal) {
+  mongoose.connect(mongoURI).then(() => {
+    Notice.update(
+      { referencenum: referenceNum }, newVal, { upsert: true },
+      (err) => {
+        console.log(err);
+        process.exit();
+      }
+    );
+  }).catch((err) => {
+    console.log(err);
+    process.exit();
+  });
+}
+
+module.exports = {
+  insertNotices: insertNotices,
+  getAllNotices: getCurrentNotices,
+  deleteNotices: deleteNotices,
+  deleteAllNotices: deleteAllNotices,
+  updateNotice: updateNotice
+};

--- a/src/Database/actions.js
+++ b/src/Database/actions.js
@@ -1,70 +1,56 @@
-const mongoose = require('mongoose');
 const Notice = require('./schema/notice.js');
 
-const mongoURI = 'mongodb://mongo/TWbackend?replicaSet=rs';
 
 async function insertNotices(notices) {
-  mongoose.connect(mongoURI).then(() => {
-    Notice.collection.insert(notices, (err) => {
-      if (err) {
-        console.log(err);
-        process.exit();
-      }
-    });
-  }).catch((err) => {
-    console.log(err);
-    console.log('Could not connect to the database. Exiting now...');
-    process.exit();
+  await Notice.collection.insert(notices, (err) => {
+    if (err) {
+      console.log(err);
+      process.exit(1);
+    }
   });
 }
 
 async function getCurrentNotices(callback) {
-  mongoose.connect(mongoURI).then(() => {
-    Notice.find({}).lean().exec((err, result) => {
-      if (err) {
-        throw err;
-      }
-      callback(result);
-    });
+  await Notice.find({}).lean().exec((err, result) => {
+    if (err) {
+      console.log(err);
+      process.exit(1);
+    }
+    callback(result);
   });
 }
 
 async function deleteNotices(notices) {
-  mongoose.connect(mongoURI).then(() => {
-    Notice.remove({ referencenum: { $in: notices } }, (err) => {
+  await Notice.remove({ referencenum: { $in: notices } }, (err) => {
+    if (err) {
       console.log(err);
-      process.exit();
-    });
-  }).catch((err) => {
-    console.log(err);
-    process.exit();
+      process.exit(1);
+    }
   });
 }
 
 async function deleteAllNotices() {
-  mongoose.connect(mongoURI).then(() => {
-    Notice.remove({}, (err) => {
+  await Notice.remove({}, (err) => {
+    if (err != null) {
       console.log(err);
-      process.exit();
-    });
-  }).catch((err) => {
-    console.log(err);
-    process.exit();
+      process.exit(1);
+    }
   });
 }
 
 async function updateNotice(referenceNum, newVal) {
-  mongoose.connect(mongoURI).then(() => {
-    Notice.update(
-      { referencenum: referenceNum }, newVal, { upsert: true },
-      (err) => {
+  await Notice.update(
+    { referencenum: referenceNum },
+    newVal,
+    { overwrite: true },
+    (err) => {
+      if (err) {
         console.log(err);
-        process.exit();
+        process.exit(1);
       }
-    );
-  }).catch((err) => {
+    }
+  ).catch((err) => {
     console.log(err);
-    process.exit();
   });
 }
 

--- a/src/Database/helpers.js
+++ b/src/Database/helpers.js
@@ -1,0 +1,49 @@
+const Notice = require('./schema/notice');
+
+/*
+* noticeFromJSONDiff creates a notice object from a JSON diff
+* used for additions
+*/
+function noticeFromJSONDiff(jn) {
+  const n = new Notice();
+  n.geocoord = { type: 'Point', coordinates: [jn.data.lat, jn.data.long] };
+  n.objectid = jn.data.objectid;
+  n.title = jn.data.title;
+  n.status = jn.data.status;
+  n.worktype = jn.data.worktype;
+  n.affectedpremises = jn.data.affectedpremises;
+  n.trafficimplications = jn.data.trafficimplications;
+  n.description = jn.data.description;
+  n.globalid = jn.data.globalid;
+  n.location = jn.data.location;
+  n.startdate = jn.data.startdate;
+  n.enddate = jn.data.enddate;
+  n.county = jn.data.county;
+  n.referencenum = jn.data.referencenum;
+  n.noticetype = jn.data.noticetype;
+  n.contactdetails = jn.data.contactdetails;
+  return n;
+}
+
+/*
+* lowercaseKeys converts the keys of an object into lowercase
+*/
+function lowercaseKeys(obj) {
+  const keys = Object.keys(obj);
+  let n = keys.length;
+  const newObj = {};
+  while (n--) {
+    const key = keys[n];
+    if (key !== '_id') {
+      // skip the Mongo _id key
+      newObj[key.toLowerCase()] = obj[key];
+    }
+  }
+  return newObj;
+}
+
+
+module.exports = {
+  noticeFromDiff: noticeFromJSONDiff,
+  lowercaseKeys: lowercaseKeys
+};

--- a/src/Database/helpers.js
+++ b/src/Database/helpers.js
@@ -42,8 +42,34 @@ function lowercaseKeys(obj) {
   return newObj;
 }
 
+/*
+* normaliseData converts an object into one that more closely resembles
+* a notice
+*/
+function normaliseData(data) {
+  return data.map((d) => {
+    const newData = lowercaseKeys(d);
+    if ('lat' in newData || 'long' in newData) {
+      newData.geocoord = {
+        coordinates: [
+          newData.lat,
+          newData.long
+        ],
+        type: 'Point'
+      };
+      delete newData.lat;
+      delete newData.long;
+    }
+
+    if ('_id' in newData) {
+      delete newData._id; // eslint-disable-line no-underscore-dangle
+    }
+    return newData;
+  });
+}
 
 module.exports = {
   noticeFromDiff: noticeFromJSONDiff,
-  lowercaseKeys: lowercaseKeys
+  lowercaseKeys: lowercaseKeys,
+  normaliseData: normaliseData
 };

--- a/src/Database/schema/notice.js
+++ b/src/Database/schema/notice.js
@@ -6,9 +6,9 @@ mongoose.Promise = require('bluebird');
  * See location information and Point datatype at https://docs.mongodb.com/manual/reference/geojson/
  */
 const noticeSchema = new mongoose.Schema({
-  geocoord: { type: String, coordinates: [Number] },
-  timeadded: Date,
-  timemodified: Date,
+  geocoord: { type: { type: String }, coordinates: [] },
+  timeadded: Number,
+  timemodified: Number,
   objectid: Number,
   worktype: String,
   title: String,
@@ -18,8 +18,8 @@ const noticeSchema = new mongoose.Schema({
   description: String,
   status: String,
   globalid: String,
-  startdate: Date,
-  enddate: Date,
+  startdate: Number,
+  enddate: Number,
   location: String,
   county: String,
   referencenum: String,

--- a/src/Database/test/actions.test.js
+++ b/src/Database/test/actions.test.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const actions = require('../actions');
+const helpers = require('../helpers');
+const parse = require('../../Diff/parse');
+const Notice = require('../schema/notice.js');
+const mongoose = require('mongoose');
+
+const mongoURI = 'mongodb://127.0.0.1:27017/TWbackendTest';
+
+function parseFunction(keyAttr) {
+  return (parseInput) => {
+    const newObj = {};
+    parseInput.forEach((inputObj) => {
+      const newInputObj = helpers.lowercaseKeys(inputObj);
+      newObj[inputObj[keyAttr]] = newInputObj;
+    });
+    return newObj;
+  };
+}
+
+function runDBTest(uri, testFunction) {
+  mongoose.connect(uri).then(() => {
+    Notice.remove({}, (err, res) => {
+      if (err) {
+        console.error(err);
+        process.exit();
+      }
+      testFunction(res);
+    });
+  }).catch((err) => {
+    console.log(err);
+    process.exit();
+  });
+}
+
+test('Database: Handle fetch service functions', (done) => { // eslint-disable-line no-undef
+  const firstDataFile = path.join(__dirname, '../../..', 'test/sample-in-mongo-test.json');
+  const secondDataFile = path.join(__dirname, '../../..', 'test/sample-in-mongo-test2.json');
+  const firstData = JSON.parse(fs.readFileSync(firstDataFile, 'utf8'));
+  const normalisedFirstData = helpers.normaliseData(firstData);
+  const secondData = JSON.parse(fs.readFileSync(secondDataFile, 'utf8'));
+  const normaisedSecondData = helpers.normaliseData(secondData);
+
+  runDBTest(mongoURI, () => actions.getAllNotices(mongoURI, (d) => {
+    // tree structure for the older data
+    const oldData = parse.keyedTree(d, parseFunction('referencenum'));
+    // expect no data to previously exist
+    expect(oldData).toMatchObject({});
+    expect(firstData.length).toBe(3);
+    const diff = parse.getDiff(oldData, firstData);
+
+    // check the diff is correct
+    expect(diff.addEvents.length).toBe(3);
+    expect(diff.removeEvents.length).toBe(0);
+    expect(diff.updateEvents.length).toBe(0);
+
+    if (diff.addEvents.length > 0) {
+      const noticesToAdd = diff.addEvents.map(helpers.noticeFromDiff);
+      actions.insertNotices(mongoURI, noticesToAdd);
+    }
+
+    if (diff.removeEvents.length > 0) {
+      // remove all old notices
+      actions.deleteNotices(mongoURI, diff.removeEvents.map(k => k.key));
+    }
+
+    if (diff.updateEvents.length > 0) {
+      diff.updateEvents.forEach((record) => {
+        // const noticeInstance = helpers.noticeFromDiff(record);
+        actions.updateNotice(mongoURI, record.referencenum, record);
+      });
+    }
+    actions.getAllNotices(mongoURI, (storedNotices) => {
+      // expect 3 notices to currently exist
+      expect(storedNotices.length).toBe(3);
+      const normalisedStored = helpers.normaliseData(storedNotices);
+      expect(normalisedStored).toEqual(normalisedFirstData);
+      // console.log(newd);
+
+      // // repeat with newer data
+      const storedData = parse.keyedTree(normalisedStored, parseFunction('referencenum'));
+      const newData = parse.keyedTree(normaisedSecondData, parseFunction('referencenum'));
+      const parsedDiff = parse.getDiff(storedData, newData);
+      expect(parsedDiff.addEvents.length).toBe(1);
+      expect(parsedDiff.removeEvents.length).toBe(1);
+      expect(parsedDiff.updateEvents.length).toBe(1);
+
+      if (parsedDiff.addEvents.length > 0) {
+        actions.insertNotices(mongoURI, parsedDiff.addEvents.map(helpers.noticeFromDiff));
+      }
+
+      if (parsedDiff.removeEvents.length > 0) {
+        // remove all old notices
+        actions.deleteNotices(mongoURI, parsedDiff.removeEvents.map(k => k.key));
+      }
+
+      if (parsedDiff.updateEvents.length > 0) {
+        parsedDiff.updateEvents.forEach((record) => {
+          const noticeInstance = helpers.noticeFromDiff(record);
+          actions.updateNotice(mongoURI, record.referencenum, noticeInstance);
+        });
+      }
+      done();
+    });
+  }));
+});

--- a/src/Database/test/helpers.test.js
+++ b/src/Database/test/helpers.test.js
@@ -1,7 +1,7 @@
 const helpers = require('../helpers');
 
 test('Database: Notice from Diff', () => { // eslint-disable-line no-undef
-  // // mock setup
+  // mock setup
   const input = {
     OBJECTID: 1,
     WORKTYPE: null,

--- a/src/Database/test/helpers.test.js
+++ b/src/Database/test/helpers.test.js
@@ -1,0 +1,83 @@
+const helpers = require('../helpers');
+
+test('Database: Notice from Diff', () => { // eslint-disable-line no-undef
+  // // mock setup
+  const input = {
+    OBJECTID: 1,
+    WORKTYPE: null,
+    TITLE: 'Essential Maintenance Works - Dublin',
+    CONTACTDETAILS: null,
+    AFFECTEDPREMISES: null,
+    TRAFFICIMPLICATIONS: null,
+    DESCRIPTION: 'Maintenance works',
+    STATUS: 'Open',
+    GLOBALID: 'd34db33f',
+    STARTDATE: 1527980400000,
+    ENDDATE: 1525388400000,
+    LOCATION: 'Dublin',
+    COUNTY: 'Dublin',
+    REFERENCENUM: 'ABC1234',
+    LONG: -1.23,
+    LAT: 44.44,
+    NOTICETYPE: ['BOILWATERNOTICE', 'TRAFFICDISRUPTIONS', 'WATEROUTAGE']
+  };
+
+  const n = helpers.noticeFromDiff({ data: helpers.lowercaseKeys(input) });
+  expect(n.objectid).toEqual(input.OBJECTID);
+  expect(n.worktype).toEqual(input.WORKTYPE);
+  expect(n.title).toEqual(input.TITLE);
+  expect(n.contactdetails).toEqual(input.CONTACTDETAILS);
+  expect(n.affectedpremises).toEqual(input.AFFECTEDPREMISES);
+  expect(n.trafficimplications).toEqual(input.TRAFFICIMPLICATIONS);
+  expect(n.description).toEqual(input.DESCRIPTION);
+  expect(n.status).toEqual(input.STATUS);
+  expect(n.globalid).toEqual(input.GLOBALID);
+  expect(n.startdate).toEqual(input.STARTDATE);
+  expect(n.enddate).toEqual(input.ENDDATE);
+  expect(n.location).toEqual(input.LOCATION);
+  expect(n.county).toEqual(input.COUNTY);
+  expect(n.referencenum).toEqual(input.REFERENCENUM);
+  expect(n.geocoord.coordinates[0]).toEqual(input.LAT);
+  expect(n.geocoord.coordinates[1]).toEqual(input.LONG);
+});
+
+test('Diff: lowercaseKeys helper', () => { // eslint-disable-line no-undef
+  const input = {
+    OBJECTID: 1,
+    WORKTYPE: null,
+    TITLE: 'Essential Maintenance Works - Dublin',
+    CONTACTDETAILS: null,
+    AFFECTEDPREMISES: null,
+    TRAFFICIMPLICATIONS: null,
+    DESCRIPTION: 'Maintenance works',
+    STATUS: 'Open',
+    GLOBALID: 'd34db33f',
+    STARTDATE: 1527980400000,
+    ENDDATE: 1525388400000,
+    LOCATION: 'Dublin',
+    COUNTY: 'Dublin',
+    REFERENCENUM: 'ABC1234',
+    LONG: -1.23,
+    LAT: 44.44,
+    NOTICETYPE: ['BOILWATERNOTICE', 'TRAFFICDISRUPTIONS', 'WATEROUTAGE']
+  };
+
+  const n = helpers.lowercaseKeys(input);
+  expect(n.objectid).toEqual(input.OBJECTID);
+  expect(n.worktype).toEqual(input.WORKTYPE);
+  expect(n.title).toEqual(input.TITLE);
+  expect(n.contactdetails).toEqual(input.CONTACTDETAILS);
+  expect(n.affectedpremises).toEqual(input.AFFECTEDPREMISES);
+  expect(n.trafficimplications).toEqual(input.TRAFFICIMPLICATIONS);
+  expect(n.description).toEqual(input.DESCRIPTION);
+  expect(n.status).toEqual(input.STATUS);
+  expect(n.globalid).toEqual(input.GLOBALID);
+  expect(n.startdate).toEqual(input.STARTDATE);
+  expect(n.enddate).toEqual(input.ENDDATE);
+  expect(n.location).toEqual(input.LOCATION);
+  expect(n.county).toEqual(input.COUNTY);
+  expect(n.referencenum).toEqual(input.REFERENCENUM);
+  expect(n.lat).toEqual(input.LAT);
+  expect(n.long).toEqual(input.LONG);
+  expect(n.noticetype).toEqual(input.NOTICETYPE);
+});

--- a/src/Diff/test/parse.test.js
+++ b/src/Diff/test/parse.test.js
@@ -6,7 +6,7 @@ test('Diff: create keyed JSON tree', () => { // eslint-disable-line no-undef
   // // mock setup
   const input = [{
     OBJECTID: 1,
-    WORKTYP: null,
+    WORKTYPE: null,
     TITLE: 'Essential Maintenance Works - Dublin',
     CONTACTDETAILS: null,
     AFFECTEDPREMISES: null,
@@ -27,7 +27,7 @@ test('Diff: create keyed JSON tree', () => { // eslint-disable-line no-undef
   const expected = {
     ABC1234: {
       OBJECTID: 1,
-      WORKTYP: null,
+      WORKTYPE: null,
       TITLE: 'Essential Maintenance Works - Dublin',
       CONTACTDETAILS: null,
       AFFECTEDPREMISES: null,
@@ -40,8 +40,8 @@ test('Diff: create keyed JSON tree', () => { // eslint-disable-line no-undef
       LOCATION: 'Dublin',
       COUNTY: 'Dublin',
       REFERENCENUM: 'ABC1234',
-      LONG: -1.23,
       LAT: 44.44,
+      LONG: -1.23,
       NOTICETYPE: ['BOILWATERNOTICE', 'TRAFFICDISRUPTIONS', 'WATEROUTAGE']
     }
   };

--- a/src/FetchService/index.js
+++ b/src/FetchService/index.js
@@ -1,9 +1,41 @@
 const apis = require('./apis');
+const notice = require('../Database/schema/notice'); // eslint-disable-line no-unused-vars
+const actions = require('../Database/actions');
+const diffParser = require('../Diff/parse');
+const helpers = require('../Database/helpers');
+
+function parseFunction(keyAttr) {
+  return (parseInput) => {
+    const newObj = {};
+    parseInput.forEach((inputObj) => {
+      // console.log(inputObj);
+      const newInputObj = helpers.lowercaseKeys(inputObj);
+      newObj[inputObj[keyAttr]] = newInputObj;
+    });
+    return newObj;
+  };
+}
 
 apis.fetchIrishWater(((data) => { // eslint-disable-line no-unused-vars
-  /*
-   * TODO:
-   * this should store the data in a database, or check
-   * for differences
-   */
+  actions.getAllNotices((d) => {
+    const oldData = diffParser.keyedTree(d, parseFunction('referencenum'));
+    const newData = diffParser.keyedTree(data, parseFunction('REFERENCENUM'));
+    const diff = diffParser.getDiff(oldData, newData);
+
+    if (diff.addEvents.length > 0) {
+      actions.insertNotices(diff.addEvents.map(helpers.noticeFromDiff));
+    }
+
+    if (diff.removeEvents.length > 0) {
+      // remove all old notices
+      actions.deleteNotices(diff.removeEvents.map(k => k.key));
+    }
+
+    if (diff.updateEvents.length > 0) {
+      diff.updateEvents.forEach((record) => {
+        const noticeInstance = helpers.noticeFromDiff(record);
+        actions.updateNotice(notice.referencenum, noticeInstance);
+      });
+    }
+  });
 }));

--- a/src/FetchService/index.js
+++ b/src/FetchService/index.js
@@ -27,35 +27,70 @@ function parseFunction(keyAttr) {
   };
 }
 
-apis.fetchIrishWater(((data) => { // eslint-disable-line no-unused-vars
-  mongoose.connect(mongoURI, {
-    // sets how many times to try reconnecting
-    reconnectTries: Number.MAX_VALUE,
-    // sets the delay between every retry (milliseconds)
-    reconnectInterval: 1000
-  }).then(async () => {
-    actions.getAllNotices(mongoURI, async (d) => {
-      const normalisedIWData = helpers.normaliseData(data);
-      const oldData = diffParser.keyedTree(d, parseFunction('referencenum'));
-      const newData = diffParser.keyedTree(normalisedIWData, parseFunction('referencenum'));
-      const diff = diffParser.getDiff(oldData, newData);
+function fetchAPIs() {
+  return new Promise((resolve) => {
+    apis.fetchIrishWater(((data) => { // eslint-disable-line no-unused-vars
+      mongoose.connect(mongoURI, {
+        // sets how many times to try reconnecting
+        reconnectTries: Number.MAX_VALUE,
+        // sets the delay between every retry (milliseconds)
+        reconnectInterval: 1000
+      }).then(async () => {
+        actions.getAllNotices(async (d) => {
+          const normalisedIWData = helpers.normaliseData(data);
+          const oldData = diffParser.keyedTree(d, parseFunction('referencenum'));
+          const newData = diffParser.keyedTree(normalisedIWData, parseFunction('referencenum'));
+          const diff = diffParser.getDiff(oldData, newData);
 
-      if (diff.addEvents.length > 0) {
-        await actions.insertNotices(mongoURI, diff.addEvents.map(helpers.noticeFromDiff));
-      }
+          if (diff.addEvents.length > 0) {
+            await actions.insertNotices(diff.addEvents.map(helpers.noticeFromDiff));
+          }
 
-      if (diff.removeEvents.length > 0) {
-        // remove all old notices
-        await actions.deleteNotices(mongoURI, diff.removeEvents.map(k => k.key));
-      }
+          if (diff.removeEvents.length > 0) {
+            // remove all old notices
+            await actions.deleteNotices(diff.removeEvents.map(k => k.key));
+          }
 
-      if (diff.updateEvents.length > 0) {
-        await diff.updateEvents.forEach(async (record) => {
-          const noticeInstance = helpers.noticeFromDiff(record);
-          await actions.updateNotice(mongoURI, notice.referencenum, noticeInstance);
+          if (diff.updateEvents.length > 0) {
+            await diff.updateEvents.forEach(async (record) => {
+              const noticeInstance = helpers.noticeFromDiff(record);
+              await actions.updateNotice(notice.referencenum, noticeInstance);
+            });
+          }
+          mongoose.disconnect();
+          resolve();
         });
-      }
-      mongoose.disconnect();
-    });
+      });
+    }));
   });
-}));
+}
+
+const options = {
+  interval: null
+};
+for (let i = 0; i < process.argv.length; i++) {
+  switch (process.argv[i]) {
+  case '--interval':
+    options.interval = process.argv[i + 1];
+    i++;
+    break;
+  case '--daily':
+    options.interval = 24 * 60 * 60 * 1000;
+    break;
+  default:
+    break;
+  }
+}
+
+if (options.interval) {
+  fetchAPIs().then(() => {});
+  setInterval(() => {
+    fetchAPIs().then(() => {
+    });
+  }, options.interval);
+} else {
+  fetchAPIs().then(() => {
+    process.exit();
+  });
+}
+

--- a/test/sample-in-mongo-test.json
+++ b/test/sample-in-mongo-test.json
@@ -1,0 +1,32 @@
+[ 
+	{
+		"title": "Essential Maintenance Works - Dublin",
+		"county": "Dublin",
+		"referencenum": "JOB1",
+		"lat": 12,
+		"long": 34,
+		"noticetype": [
+			"WATEROUTAGE"
+		]
+	},
+	{
+	    "title": "Essential Maintenance Works - Waterford",
+	    "county": "Waterford",
+	    "referencenum": "JOB2",
+	    "lat": 56,
+	    "long": 78,
+	    "noticetype": [
+			"WATEROUTAGE"
+	    ]
+	},
+	{
+		"title": "Essential Maintenance Works - Waterford",
+		"county": "Waterford",
+		"referencenum": "JOB3",
+		"lat": 52.305141507939,
+		"long": -7.4948703306578,
+		"noticetype": [
+			"WATEROUTAGE"
+		]
+	}
+]

--- a/test/sample-in-mongo-test2.json
+++ b/test/sample-in-mongo-test2.json
@@ -1,0 +1,32 @@
+[ 
+  	{
+	    "title": "Essential Maintenance Works - Leitrim",
+	    "county": "Leitrim",
+	    "referencenum": "JOB4",
+	    "lat": 53.926507006511,
+	    "long": -8.0085297962951,
+	    "noticetype": [
+			"WATEROUTAGE"
+	    ]
+	},
+	{
+	    "title": "Essential Maintenance Works - Waterford",
+	    "county": "Waterford",
+	    "referencenum": "JOB2",
+	    "lat": 56,
+	    "long": 78,
+	    "noticetype": [
+			"WATEROUTAGE", "BOILNOTICE"
+	    ]
+	},
+	{
+		"title": "Essential Maintenance Works - Waterford",
+		"county": "Waterford",
+		"referencenum": "JOB3",
+		"lat": 52.305141507939,
+		"long": -7.4948703306578,
+		"noticetype": [
+			"WATEROUTAGE"
+		]
+	}
+]


### PR DESCRIPTION
Really basic implementation of the mongo interactions for the fetch service.

More complex tests should be added in a future commit, but for now this should be enough to satisfy the API calls.

Also for a future commit, running the fetch service as a standalone docker container